### PR TITLE
Minify CSS components definition on the fly + Expose classes

### DIFF
--- a/cjs/index.js
+++ b/cjs/index.js
@@ -1,6 +1,14 @@
 'use strict';
-const {init, HTMLElement, HTMLTemplateElement} = require('basichtml');
-const {document} = init({});
+const {
+  init,
+  CustomElementRegistry,
+  Document,
+  HTMLElement,
+  HTMLTemplateElement
+} = require('basichtml');
+const {customElements, document, window} = init({});
+
+const csso = (m => m.__esModule ? /* istanbul ignore next */ m.default : /* istanbul ignore next */ m)(require('csso'));
 
 const {
   define: heresyDefine,
@@ -16,11 +24,12 @@ const configurable = true;
 const documents = new WeakMap;
 let waiting = new Map;
 const cleanWait = $ => {
-  const styling = documents.get(document);
+  const doc = window.document || document;
+  const styling = documents.get(doc);
   styling && styling.forEach(value => {
     if (value.length) {
-      const {head} = document;
-      const style = document.createElement('style');
+      const {head} = doc;
+      const style = doc.createElement('style');
       style.setAttribute('type', 'text/css');
       style.textContent = value;
       head.insertBefore(style, head.lastChild);
@@ -37,13 +46,14 @@ const {defineProperty} = Object;
 const define = (...args) => {
   const Class = args.length < 2 ? args[0] : args[1];
   if ('style' in Class) {
+    const doc = window.document || document;
     const {style} = Class;
-    const styling = documents.get(document) ||
-                    documents.set(document, new Map).get(document);
+    const styling = documents.get(doc) ||
+                    documents.set(doc, new Map).get(doc);
     defineProperty(Class, 'style', {
       configurable,
       value() {
-        styling.set(Class, style.apply(Class, arguments));
+        styling.set(Class, csso.minify(style.apply(Class, arguments)).css);
         return '';
       }
     });
@@ -75,16 +85,19 @@ const render = (where, what) => {
   switch (true) {
     case where instanceof HTMLElement:
       return cleanWait(heresyRender(where, what));
-    case where === document:
+    case where instanceof Document:
       heresyRender(template, what);
-      document.documentElement = template.firstElementChild;
-      return cleanWait(document);
+      where.documentElement = template.firstElementChild;
+      return cleanWait(where);
     default:
       heresyRender(template, what);
       return where.write(cleanWait(template).innerHTML);
   }
 };
 
+exports.CustomElementRegistry = CustomElementRegistry;
+exports.Document = Document;
+exports.customElements = customElements;
 exports.document = document;
 exports.define = define;
 exports.render = render;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "basichtml": "^0.24.0",
+    "csso": "^3.5.1",
     "heresy": "^0.13.0"
   },
   "directories": {


### PR DESCRIPTION
To use a document per page, Document and CustomElementRegistry might be handy.

This MR allows minification + exposes extra info to the user.